### PR TITLE
Prevent exceptions when input parameters are unsuitable

### DIFF
--- a/LoopStructural/modelling/core/geological_model.py
+++ b/LoopStructural/modelling/core/geological_model.py
@@ -378,7 +378,7 @@ class GeologicalModel:
             nsteps = np.ceil((bb[1, :] - bb[0, :]) / step_vector).astype(int)
             if np.any(np.less(nsteps, 3)):
                 logger.error("Cannot create interpolator: number of steps is too small")
-                return interpolator
+                return None
             # create a structured grid using the origin and number of steps
             grid_id = 'grid_{}'.format(nelements)
             grid = self.support.get(grid_id, StructuredGrid(origin=bb[0, :],

--- a/LoopStructural/modelling/features/structural_frame_builder.py
+++ b/LoopStructural/modelling/features/structural_frame_builder.py
@@ -46,14 +46,14 @@ class StructuralFrameBuilder:
         # list of interpolators
         # self.interpolators = []
         # Create the interpolation objects by copying the template
-
         if interpolators is None:
-            interpolators = []
-            interpolators.append(interpolator)
-            interpolators.append(interpolator.copy())
-            interpolators.append(interpolator.copy())
-        if interpolators is None and interpolator is None:
-            raise BaseException
+            if interpolator is not None:
+                interpolators = []
+                interpolators.append(interpolator)
+                interpolators.append(interpolator.copy())
+                interpolators.append(interpolator.copy())
+            else:
+                raise BaseException("Missing interpolator")
         # self.builders
         self.builders.append(
             GeologicalFeatureInterpolator(interpolators[0],
@@ -132,7 +132,7 @@ class StructuralFrameBuilder:
                 "Not enough constraints for structural frame coordinate 0, \n"
                 "Add some more and try again.")
         # make sure that all of the coordinates are using the same region
-        if gx_feature.get_interpolator().region_function is not None:
+        if gx_feature is not None and gx_feature.get_interpolator().region_function is not None:
             self.builders[1].interpolator.set_region(gx_feature.get_interpolator().region_function)
             self.builders[2].interpolator.set_region(gx_feature.get_interpolator().region_function)
             if 'data_region' in kwargs:


### PR DESCRIPTION
A number of little fixes to prevent exceptions when input parameters are unsuitable - when:
1. number of steps is too small
2. No value_data is found
3. Both interpolator and interpolators are None
4. gx_feature is None