### PR TITLE
Revert to 'thickness' and let LoopProjectFile select which calculator to use

### DIFF
--- a/LoopStructural/modelling/input/project_file.py
+++ b/LoopStructural/modelling/input/project_file.py
@@ -30,7 +30,7 @@ class LoopProjectfileProcessor(ProcessInputData):
         thicknesses = dict(
             zip(
                 projectfile["stratigraphicLog"].name,
-                projectfile["stratigraphicLog"].ThicknessMedian,
+                projectfile["stratigraphicLog"].thickness,
             )
         )
         fault_properties = self.projectfile.faultLog


### PR DESCRIPTION
With the change to LoopProjectFile this reverts the thickness variable to 'thickness' instead of the ThicknessMedian which now contains mutliple thickness values (one for each thickness calculator)