### PR TITLE
fix: include nsteps in bounding box initialization when creating buffer

### DIFF
--- a/LoopStructural/datatypes/_bounding_box.py
+++ b/LoopStructural/datatypes/_bounding_box.py
@@ -281,6 +281,7 @@ class BoundingBox:
             origin=origin,
             maximum=maximum,
             global_origin=self.global_origin,
+            nsteps=self.nsteps,
             dimensions=self.dimensions,
         )
 


### PR DESCRIPTION
<h3>What &amp; Why</h3>
<p>Calling <code inline="">BoundingBox.with_buffer()</code> currently discards the user-supplied spatial resolution (<code inline="">nsteps</code>) and falls back to the constructor default of <code inline="">[50, 50, 25]</code>.<br>
This silently changes grid density downstream (e.g., when building regular grids or structured grids from the new box).</p>
<p><strong>Expected</strong>: the new, buffered box should inherit the parent’s <code inline="">nsteps</code> unless the caller explicitly overrides it.<br>
<strong>Actual</strong>: resolution is reset to the default.</p>
<hr>
<h3>Changes</h3>

File | Change
-- | --
LoopStructural/datatypes/_bounding_box.py | Forward nsteps when instantiating the buffered box


<pre><code class="language-diff">@@     def with_buffer(self, buffer: float = 0.2) -&gt; BoundingBox:
         return BoundingBox(
             origin=origin,
             maximum=maximum,
             global_origin=self.global_origin,
+            nsteps=self.nsteps,      # &lt;-- keep user-defined resolution
             dimensions=self.dimensions,
         )
</code></pre>
<p>No other behaviour is touched.</p>
<hr>

<h3>Impact / Backwards Compatibility </h3>
<ul>
<li>
<p>Pure bug-fix, no API changes.</p>
</li>
<li>
<p>Existing code that relied on the previous behaviour will now get the expected resolution.</p>
</li>
</ul>
</body></html>