### PR TITLE
test: cover from_processor with a stratigraphic column

### DIFF
--- a/LoopStructural/modelling/core/geological_model.py
+++ b/LoopStructural/modelling/core/geological_model.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 import pathlib
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -834,8 +835,9 @@ class GeologicalModel:
         # if the colour for a unit hasn't been specified we can just sample from
         # a colour map e.g. tab20
         logger.info("Adding stratigraphic column to model")
-        raise DeprecationWarning(
-            "set_stratigraphic_column is deprecated, use model.stratigraphic_column.add_units instead"
+        warnings.warn(
+            "set_stratigraphic_column is deprecated, use model.stratigraphic_column.add_units instead",
+            DeprecationWarning,
         )
         for i, g in enumerate(stratigraphic_column.keys()):
             if g == 'faults':

--- a/tests/unit/input/test_data_processor.py
+++ b/tests/unit/input/test_data_processor.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pandas as pd
 
+from LoopStructural import GeologicalModel
 from LoopStructural.modelling import ProcessInputData
 from LoopStructural.utils import rng
 
@@ -14,3 +15,27 @@ def test_create_processor():
         contacts=df, stratigraphic_order=stratigraphic_order, thicknesses=thicknesses
     )
     assert (processor.data["val"].unique() == np.array([0.5, 0])).all()
+
+
+def test_from_processor_populates_stratigraphic_column():
+    """
+    Regression test: from_processor crashed with a DeprecationWarning raised by
+    set_stratigraphic_column when assigning the processor's column to the model.
+    """
+    df = pd.DataFrame(rng.random(size=(10, 3)), columns=["X", "Y", "Z"])
+    df["name"] = [f"unit_{name % 2}" for name in range(10)]
+    stratigraphic_order = [("sg", ["unit_0", "unit_1", "basement"])]
+    thicknesses = {"unit_0": 1.0, "unit_1": 0.5}
+    processor = ProcessInputData(
+        contacts=df,
+        stratigraphic_order=stratigraphic_order,
+        thicknesses=thicknesses,
+        origin=np.zeros(3),
+        maximum=np.ones(3),
+    )
+
+    model = GeologicalModel.from_processor(processor)
+
+    unit_names = [unit.name for unit in model.stratigraphic_column.order if hasattr(unit, "name")]
+    assert "unit_0" in unit_names
+    assert "unit_1" in unit_names


### PR DESCRIPTION
Related to #296

`GeologicalModel.from_processor` had no test coverage: when `set_stratigraphic_column` raised `DeprecationWarning` unconditionally (#296) nothing in the suite caught it. The fix for that has since landed through #300, so this PR is reduced to the regression test.

The test builds a small synthetic processor and asserts `from_processor` completes and populates the stratigraphic column. It passes against current master.