### PR TITLE
fix: correct fault-proximity gradient retry loop and stop set_stratigraphic_column from wiping state

### DIFF
--- a/LoopStructural/modelling/core/geological_model.py
+++ b/LoopStructural/modelling/core/geological_model.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 import pathlib
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -830,13 +831,15 @@ class GeologicalModel:
         }
 
         """
+        warnings.warn(
+            "set_stratigraphic_column is deprecated, use model.stratigraphic_column.add_units instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         self.stratigraphic_column.clear(basement=False)
         # if the colour for a unit hasn't been specified we can just sample from
         # a colour map e.g. tab20
         logger.info("Adding stratigraphic column to model")
-        raise DeprecationWarning(
-            "set_stratigraphic_column is deprecated, use model.stratigraphic_column.add_units instead"
-        )
         for i, g in enumerate(stratigraphic_column.keys()):
             if g == 'faults':
                 logger.info('Not adding faults to stratigraphic column')

--- a/LoopStructural/modelling/features/_geological_feature.py
+++ b/LoopStructural/modelling/features/_geological_feature.py
@@ -202,6 +202,7 @@ class GeologicalFeature(BaseFeature):
             tetrahedron = regular_tetraherdron_for_points(pos, element_scale_parameter)
 
             while not resolved:
+                resolved = True
                 for f in self.faults:
                     v = (
                         f[0]
@@ -215,8 +216,7 @@ class GeologicalFeature(BaseFeature):
                         )
                         element_scale_parameter *= 0.5
                         tetrahedron = regular_tetraherdron_for_points(pos, element_scale_parameter)
-
-                resolved = True
+                        resolved = False
 
             tetrahedron_faulted = self._apply_faults(np.array(tetrahedron.reshape(-1, 3))).reshape(
                 tetrahedron.shape


### PR DESCRIPTION
Split out of #298 / #299. PR 5 of 9 in the stack — depends on #300 (base branch only; this fix doesn't touch intrusions code). Starts the "core refactor" line of the stack, independent of the map2loop/visualisation line (#301-#303).

Fixes #296: `set_stratigraphic_column` raised `DeprecationWarning` unconditionally, which broke `GeologicalModel.from_processor`. Emits the warning with `warnings.warn` instead so the legacy dict format keeps working. Also corrects the fault-proximity gradient retry loop in `_geological_feature.py`.