### PR TITLE
fix: keep unprefixed v* tags for the LoopStructural release-please component

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,8 @@
   "packages": {
     ".": {
       "release-type": "python",
-      "component": "LoopStructural"
+      "component": "LoopStructural",
+      "include-component-in-tag": false
     },
     "packages/loop_common": {
       "release-type": "python",


### PR DESCRIPTION
## Summary
- Fixes a regression from #312: repointing the `LoopStructural` component's path to `.` let release-please derive its component name from `pyproject.toml`, which switched tag generation to the manifest-mode default of prefixing tags with the component name (`LoopStructural-v*`).
- No such tags exist in this repo's history — every past release used a plain `v*` tag (`v1.7.1`, `v1.7.0`, ...). Confirmed directly from the release-please run log that produced PR #313:
  ```
  ❯ looking for tagName: LoopStructural-v1.7.1
  ✔ No latest release found for path: ., component: LoopStructural, but a previous version (1.7.1) was specified in the manifest.
  ❯ commits: 415
  ✔ Considering: 415 commits
  ```
  plus ~100 repeats of `⚠ Found release tag with component '', but not configured in manifest` — one per existing unprefixed tag, each rejected because it doesn't match the newly-expected `LoopStructural-v*` scheme. With no matching tag, release-please fell back to walking all 415 commits in the repo's history, producing PR #313's regressive `.: "1.6.5"` manifest bump and the giant stale changelog dump.
  `include-component-in-tag: false` restores the historical unprefixed tag scheme, so release-please finds `v1.7.1` as the last release again.
- Also removes `packages/loop_interpolation/src/loop_interpolation/loopsolver/version.py`, a stray unused file (not imported anywhere; `loop_interpolation` already has a static version in its own `pyproject.toml`). It's collateral damage from the same path change: release-please's generic "find any file named `version.py`" search used to be scoped to the old `LoopStructural/` subdirectory, and now scans the whole repo, which is why this unrelated file showed up in PR #313's diff too.

## Test plan
- [x] Confirmed via `git tag -l` that all past LoopStructural releases used plain `v*` tags (`v1.6.5` ... `v1.7.1`), while the workspace sub-packages use prefixed tags (`loop-common-v0.0.2`).
- [x] Confirmed via the release-please run log (quoted above) exactly why `v1.7.1` wasn't found and where the 415-commit fallback came from.
- [x] Confirmed `loopsolver/version.py` has no importers anywhere in the repo.
- [ ] After merge, confirm the release-please workflow regenerates PR #313 with a correct (or empty) diff instead of the `1.6.5` downgrade, and no longer touches `loopsolver/version.py`.

⚠️ PR #313 (the bad release-please PR) must not be merged before or independently of this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)