### PR TITLE
ci: allow manually triggering the release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,6 +2,7 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch: {}
 env:
     PACKAGE_NAME: LoopStructural
 permissions:


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` to `.github/workflows/release-please.yml` so it can be run on demand from the Actions tab (or `gh workflow run`), instead of only firing on push to `master`.
- Motivated by today's release-please deadlock (PR #313): there was no way to re-run the workflow to verify the fix without waiting for another push to `master`.

## Test plan
- [ ] After merge, confirm `gh workflow run release-please.yml --ref master` succeeds and the run reaches `Creating releases` or cleanly finds nothing pending, instead of the `outstanding, untagged` abort seen earlier today.