### PR TITLE
ci: fix map2loop/visualisation release-please version bump

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -15,11 +15,13 @@
     },
     "packages/map2loop": {
       "release-type": "python",
-      "component": "map2loop"
+      "component": "map2loop",
+      "release-as": "3.4.0"
     },
     "packages/loopstructural_visualisation": {
       "release-type": "python",
-      "component": "loopstructuralvisualisation"
+      "component": "loopstructuralvisualisation",
+      "release-as": "0.2.0"
     }
   }
 }


### PR DESCRIPTION
## Summary
- The open release-please PR (#318) proposed version `1.6.5` for both `map2loop` and `loopstructuralvisualisation`, instead of a proper bump from their real current versions (`3.3.1` and `0.1.17`).
- Root cause: neither package has a component-scoped release-please tag yet (they were only just added to the workspace in #301/#302), so release-please had no correct anchor point and fell back to misreading one of the repo's old generic `v1.6.5` LoopStructural tags.
- One-time `release-as` pin to the correct next versions (minor bump, since each package picked up two `feat:` commits in the merged stack): `map2loop` → `3.4.0`, `loopstructuralvisualisation` → `0.2.0`.

## Test plan
- [ ] Merge this PR
- [ ] Confirm release-please regenerates PR #318 with `map2loop 3.4.0` and `loopstructuralvisualisation 0.2.0` instead of `1.6.5`
- [ ] Remove the `release-as` pins once #318 merges and each package has its own release-please tag